### PR TITLE
Feature: Allocations List with Weekly View Mode

### DIFF
--- a/components/misc/AllocationsPage.tsx
+++ b/components/misc/AllocationsPage.tsx
@@ -12,15 +12,18 @@ import { useRouter } from 'next/navigation';
 import { Pagination } from '@/components/ui/pagination';
 import { DEFAULT_ITEMS_PER_PAGE } from '@/utils/constants';
 import { CalendarView } from '@/components/ui/calendar-view';
+import { WeeklyView } from '@/components/ui/weekly-view';
 import { useTenant } from '@/utils/tenant-context';
 import { toast } from '@/components/ui/use-toast';
 import { HeatmapView } from '@/components/ui/heatmap-view';
+
+import { Clock } from 'lucide-react';
 
 interface AllocationsPageProps {
   user: User;
 }
 
-type ViewMode = 'list' | 'calendar' | 'heatmap';
+type ViewMode = 'list' | 'calendar' | 'heatmap' | 'weekly';
 
 export default function AllocationsPage({ user }: AllocationsPageProps) {
   const [allocations, setAllocations] = useState<any[]>([]);
@@ -132,6 +135,15 @@ export default function AllocationsPage({ user }: AllocationsPageProps) {
             <Button
               variant="outline"
               size="icon"
+              onClick={() => setViewMode('weekly')}
+              title="Weekly View"
+              className={viewMode === 'weekly' ? 'bg-accent' : ''}
+            >
+              <Clock className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
               onClick={() => setViewMode('heatmap')}
               title="Heatmap View"
               className={viewMode === 'heatmap' ? 'bg-accent' : ''}
@@ -197,6 +209,8 @@ export default function AllocationsPage({ user }: AllocationsPageProps) {
             </>
           ) : viewMode === 'calendar' ? (
             <CalendarView allocations={allocations} />
+          ) : viewMode === 'weekly' ? (
+            <WeeklyView allocations={allocations} />
           ) : (
             <HeatmapView allocations={allocations} />
           )}

--- a/components/ui/weekly-view.tsx
+++ b/components/ui/weekly-view.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+interface Allocation {
+  id: string;
+  employee_name: string;
+  project_name: string;
+  start_date: string;
+  end_date: string;
+  allocation_percentage: number;
+}
+
+interface WeeklyViewProps {
+  allocations: Allocation[];
+}
+
+export function WeeklyView({ allocations }: WeeklyViewProps) {
+  const router = useRouter();
+
+  const getWeekRange = (date: Date) => {
+    const start = new Date(date);
+    start.setDate(date.getDate() - date.getDay());
+    const end = new Date(start);
+    end.setDate(start.getDate() + 6);
+    return { start, end };
+  };
+
+  const weeks = Array.from({ length: 12 }).map((_, i) => {
+    const now = new Date();
+    now.setDate(now.getDate() - (i * 7));
+    const { start: weekStart, end: weekEnd } = getWeekRange(now);
+    
+    const weekAllocations = allocations.filter(allocation => {
+      const startDate = new Date(allocation.start_date);
+      const endDate = new Date(allocation.end_date);
+      return (startDate <= weekEnd && endDate >= weekStart);
+    });
+
+    return {
+      weekStart,
+      weekEnd,
+      allocations: weekAllocations
+    };
+  }).reverse();
+
+  const formatDate = (date: Date) => {
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    return `${months[date.getMonth()]} ${date.getDate()}`;
+  };
+
+  return (
+    <div className="space-y-6">
+      {weeks.map(({ weekStart, weekEnd, allocations: weekAllocations }) => (
+        <div key={weekStart.toISOString()} className="rounded-lg border p-4">
+          <div className="font-semibold mb-3 text-lg">
+            {formatDate(weekStart)} - {formatDate(weekEnd)}, {weekEnd.getFullYear()}
+          </div>
+          {weekAllocations.length > 0 ? (
+            <div className="grid gap-2">
+              {weekAllocations.map(allocation => (
+                <div 
+                  key={allocation.id}
+                  className="flex items-center justify-between p-3 bg-muted rounded-md hover:bg-accent transition-colors cursor-pointer"
+                  onClick={() => router.push(`/allocations/edit/${allocation.id}`)}
+                >
+                  <div className="flex-1">
+                    <div className="font-medium">{allocation.employee_name}</div>
+                    <div className="text-sm text-muted-foreground">{allocation.project_name}</div>
+                  </div>
+                  <div className="text-right">
+                    <div className="font-medium">{allocation.allocation_percentage}%</div>
+                    <div className="text-sm text-muted-foreground">
+                      {formatDate(new Date(allocation.start_date))} - {formatDate(new Date(allocation.end_date))}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center text-muted-foreground py-4">
+              No allocations this week
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Features: Add a new view mode into Allocations List Page: Weekly View Mode
Use-case:
```mermaid
graph TD;
    Allocations_Page-->Choose_Weekly_View_Mode-->Render_Allocations_Page_with_Weekly_View_Mode
```
Screenshot:
1. Default view mode: Calendar View
![image](https://github.com/user-attachments/assets/fd9a5b91-38f5-4f0a-8a38-25862b0db38b)
2. Weekly view mode
![image](https://github.com/user-attachments/assets/6abc9828-06c9-40b4-9738-6fca446859aa)
