### PR TITLE
Feature: Show Employees of the Department

### DIFF
--- a/components/misc/DepartmentsPage.tsx
+++ b/components/misc/DepartmentsPage.tsx
@@ -13,6 +13,8 @@ import { useTenant } from '@/utils/tenant-context';
 import { toast } from '@/components/ui/use-toast';
 import { Department } from '@/utils/types';
 
+import { DepartmentEmployeesDialog } from "@/components/ui/department-employees-dialog";
+
 interface DepartmentsPageProps {
   user: User;
 }
@@ -26,6 +28,7 @@ interface DepartmentNodeProps {
 
 const DepartmentNode = ({ department, level, onEdit, allDepartments }: DepartmentNodeProps) => {
   const [isExpanded, setIsExpanded] = useState(true);
+  const [showEmployees, setShowEmployees] = useState(false);
   
   const childDepartments = allDepartments.filter(d => d.parent_department_id === department.id);
   const hasChildren = childDepartments.length > 0;
@@ -35,9 +38,18 @@ const DepartmentNode = ({ department, level, onEdit, allDepartments }: Departmen
       <div 
         className={`flex items-center p-2 hover:bg-muted/50 ${level > 0 ? 'ml-6' : ''}`}
       >
-        <div className="flex-1 flex items-center gap-2">
+        <div 
+          className="flex-1 flex items-center gap-2 cursor-pointer"
+          onClick={() => setShowEmployees(true)}
+        >
           {hasChildren && (
-            <button onClick={() => setIsExpanded(!isExpanded)} className="p-1">
+            <button 
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsExpanded(!isExpanded);
+              }} 
+              className="p-1"
+            >
               {isExpanded ? (
                 <ChevronDown className="h-4 w-4" />
               ) : (
@@ -54,11 +66,22 @@ const DepartmentNode = ({ department, level, onEdit, allDepartments }: Departmen
         <Button 
           variant="ghost" 
           size="icon"
-          onClick={() => onEdit(department.id)}
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit(department.id);
+          }}
         >
           <Settings className="h-4 w-4" />
         </Button>
       </div>
+
+      <DepartmentEmployeesDialog
+        isOpen={showEmployees}
+        onClose={() => setShowEmployees(false)}
+        department={department}
+        allDepartments={allDepartments}
+      />
+
       {hasChildren && isExpanded && (
         <div className="border-l ml-3">
           {childDepartments.map((child) => (
@@ -75,6 +98,60 @@ const DepartmentNode = ({ department, level, onEdit, allDepartments }: Departmen
     </div>
   );
 };
+
+// const DepartmentNode = ({ department, level, onEdit, allDepartments }: DepartmentNodeProps) => {
+//   const [isExpanded, setIsExpanded] = useState(true);
+  
+//   const childDepartments = allDepartments.filter(d => d.parent_department_id === department.id);
+//   const hasChildren = childDepartments.length > 0;
+
+//   const [showEmployees, setShowEmployees] = useState(false);
+
+//   return (
+//     <div className="w-full">
+//       <div 
+//         className={`flex items-center p-2 hover:bg-muted/50 ${level > 0 ? 'ml-6' : ''}`}
+//       >
+//         <div className="flex-1 flex items-center gap-2">
+//           {hasChildren && (
+//             <button onClick={() => setIsExpanded(!isExpanded)} className="p-1">
+//               {isExpanded ? (
+//                 <ChevronDown className="h-4 w-4" />
+//               ) : (
+//                 <ChevronRight className="h-4 w-4" />
+//               )}
+//             </button>
+//           )}
+//           {!hasChildren && <div className="w-6" />}
+//           <span>{department.name}</span>
+//           <span className={`ml-2 text-xs ${department.is_active ? 'text-green-600' : 'text-red-600'}`}>
+//             ({department.is_active ? 'Active' : 'Inactive'})
+//           </span>
+//         </div>
+//         <Button 
+//           variant="ghost" 
+//           size="icon"
+//           onClick={() => onEdit(department.id)}
+//         >
+//           <Settings className="h-4 w-4" />
+//         </Button>
+//       </div>
+//       {hasChildren && isExpanded && (
+//         <div className="border-l ml-3">
+//           {childDepartments.map((child) => (
+//             <DepartmentNode
+//               key={child.id}
+//               department={child}
+//               level={level + 1}
+//               onEdit={onEdit}
+//               allDepartments={allDepartments}
+//             />
+//           ))}
+//         </div>
+//       )}
+//     </div>
+//   );
+// };
 
 export default function DepartmentsPage({ user }: DepartmentsPageProps) {
   const [departments, setDepartments] = useState<Department[]>([]);

--- a/components/ui/department-employees-dialog.tsx
+++ b/components/ui/department-employees-dialog.tsx
@@ -1,0 +1,94 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Employee, Department } from "@/utils/types";
+import { useEffect, useState } from "react";
+import { createClient } from "@/utils/supabase/client";
+import { toast } from "@/components/ui/use-toast";
+
+import { getDepartmentEmployees } from "@/utils/supabase/queries";
+
+interface DepartmentEmployeesDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  department: Department;
+  allDepartments: Department[];
+}
+
+export function DepartmentEmployeesDialog({ 
+    isOpen, 
+    onClose, 
+    department,
+    allDepartments 
+}: DepartmentEmployeesDialogProps) {
+    const [employees, setEmployees] = useState<Employee[]>([]);
+    const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadEmployees();
+    }
+  }, [isOpen, department.id]);
+
+  const getSubDepartmentIds = (deptId: string): string[] => {
+    const subDepts = allDepartments.filter(d => d.parent_department_id === deptId);
+    const subDeptIds = subDepts.map(d => d.id);
+    subDepts.forEach(d => {
+      subDeptIds.push(...getSubDepartmentIds(d.id));
+    });
+    return subDeptIds;
+  };
+
+  const loadEmployees = async () => {
+    try {
+      setLoading(true);
+      const supabase = createClient();
+      const employees = await getDepartmentEmployees(supabase, department.id);
+      
+      if (!employees) {
+        throw new Error('Failed to fetch employees');
+      }
+
+      setEmployees(employees);
+    } catch (error) {
+      console.error('Error loading employees:', error);
+      toast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to load employees",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Employees in {department.name}</DialogTitle>
+        </DialogHeader>
+        {loading ? (
+          <div>Loading...</div>
+        ) : (
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Department</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {employees.map((employee) => (
+                  <tr key={employee.id}>
+                    <td>{employee.given_name}</td>
+                    <td>{employee.company_email}</td>
+                    <td>{employee.is_active ? 'Active' : 'Inactive'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
This feature is for Issue: "Implement a brand new feature for this Application, whatever you think it is useful #4"
Feature: Choose a department to display all the employee information of the department and its sub-departments.
Use-case:
```mermaid
graph TD;
    Department_List_View-->Choose_Department;
    Choose_Department-->Fetch_Employees_of_this_Department;
    Choose_Department-->Fetch_Employees_of_Its_Sub_Department;
    Fetch_Employees_of_this_Department-->Return_Employees_Data;
    Fetch_Employees_of_Its_Sub_Department-->Return_Employees_Data;
    Return_Employees_Data-->Show_Employees_of_Department_List;
```
Screenshot:
1. Department Page
![image](https://github.com/user-attachments/assets/56ceb208-0b46-4992-8cf1-5a950a3a1c4e)
- We can see that: "IT" department has sub-department is "Web", "Sale" department has sub-department is "Marketing"
2 Department's Employees View
2.1 Web Department
![image](https://github.com/user-attachments/assets/b01f5847-7c47-4031-b39c-1bda57640c5e)
- "Web" department don't have sub-department, so we will only show employees in "Web" department
2.2 IT department
![image](https://github.com/user-attachments/assets/b1aebb4a-dad0-4b8b-a41f-31a071457f8f)
- "IT" department has sub-department is "Web", so we will show all employees in both "IT" and "Web" department